### PR TITLE
Fix import for mujoco envs and inverted_pendulum mujoco obs dimension

### DIFF
--- a/pybulletgym/envs/mujoco/envs/env_bases.py
+++ b/pybulletgym/envs/mujoco/envs/env_bases.py
@@ -1,7 +1,7 @@
 import gym, gym.spaces, gym.utils, gym.utils.seeding
 import numpy as np
 import pybullet
-from pybullet_envs.bullet import bullet_client
+from pybullet_utils import bullet_client
 
 from pkg_resources import parse_version
 

--- a/pybulletgym/envs/mujoco/robots/pendula/inverted_pendulum.py
+++ b/pybulletgym/envs/mujoco/robots/pendula/inverted_pendulum.py
@@ -47,6 +47,6 @@ class InvertedPendulum(MJCFBasedRobot):
         qpos = np.array([x, self.theta])  # shape (2,)
         qvel = np.array([vx, theta_dot])  # shape (2,)
 
-        return np.array([
+        return np.concatenate([
             qpos,   # self.sim.data.qpos
-            qvel])  # self.sim.data.qvel
+            qvel]).ravel() # self.sim.data.qvel


### PR DESCRIPTION
My two proposed changes are not related. Feel if you want me to submit them separately.

The first change in ` pybulletgym/envs/mujoco/envs/env_bases.py ` was already submitted for robotschool environments. This just reflects the same change due to a renaming for the mujoco envs.

The second change is due to the fact that the observations returned should be a 1-D array, not a 2x2 array. The current implementation fails if you combine the environment with existing agents from stable_baselines. Also, this change makes things more consistent.