### PR TITLE
Fixed Ant never sending the done signal

### DIFF
--- a/pybulletgym/envs/mujoco/robots/locomotors/ant.py
+++ b/pybulletgym/envs/mujoco/robots/locomotors/ant.py
@@ -26,4 +26,4 @@ class Ant(WalkerBase, MJCFBasedRobot):
         ])
 
     def alive_bonus(self, z, pitch):
-        return +1 if z > 0.26 else -1  # 0.25 is central sphere rad, die if it scrapes the ground
+        return +1 if z - self.initial_z > 0.26 else -1  # 0.25 is central sphere rad, die if it scrapes the ground


### PR DESCRIPTION
Noticed this when I was trying to find a fix for [this issue](https://github.com/benelot/pybullet-gym/issues/66). The bug seems to be with these two lines:

https://github.com/benelot/pybullet-gym/blob/bc68201c8101c4e30dde95f425647a0709ee2f29/pybulletgym/envs/mujoco/robots/locomotors/ant.py#L29

and

https://github.com/benelot/pybullet-gym/blob/bc68201c8101c4e30dde95f425647a0709ee2f29/pybulletgym/envs/mujoco/envs/locomotion/walker_base_env.py#L59-L60

I'm not sure if it should be changed in `Ant` or in `WalkerBaseMuJoCoEnv` not sure if other envs could benefit from this too? I made the change in Ant so as not to affect other envs. 

Steps to reproduce the bug, simply run:

```
env = gym.make('AntMuJoCoEnv-v0')
env.render()
env.reset()
done = False
step = 0
while not done:
    _, _, done, _ = env.step([0] * 8)
    step += 1

print(step)
```

It should print 1000 indicating that the Ant run for the max number of steps, but its torso should have been touching the ground the whole time, which is undesired behavior.